### PR TITLE
S2Eのログデータをinflux DBに挿入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ vendor/pkg/
 pyenv
 Vagrantfile
 
-.DS_Store
+log-db/influxdb_data

--- a/api-server/api.yml
+++ b/api-server/api.yml
@@ -191,6 +191,14 @@ components:
           type: string
           enum: ["running", "completed", "stopped", "failed"]
           example: "running"
+        start_date_time:
+          type: string
+          format: date-time
+          example: "2023-10-01T00:00:00Z"
+        end_date_time:
+          type: string
+          format: date-time
+          example: "2023-10-01T00:00:00Z"
 
     Pass:
       type: object

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,25 @@ services:
 
   # grafana:
 
-  # logdb:
+  log-db:
+    image: influxdb:2.7.11
+    container_name: "log-db"
+    ports:
+      - 8086:8086
+    # volumes:
+    #   - ./log-db/data:/var/lib/influxdb2
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=admin
+      - DOCKER_INFLUXDB_INIT_PASSWORD=adminadmin
+      - DOCKER_INFLUXDB_INIT_ORG=satellite-cloud
+      - DOCKER_INFLUXDB_INIT_BUCKET=simulation
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=admin-token
+    # 起動前にデータを全部削除してから influxd を立ち上げ
+    command: >
+      sh -c "rm -rf /var/lib/influxdb2/* && influxd"
+    volumes:
+      - log-db/influxdb_data:/var/lib/influxdb2
 
   simulator:
     container_name: simulator
@@ -38,4 +56,4 @@ services:
       - "8910:8910"
       - "8920:80"
     tty: true
-    platform: linux/arm64 # ホストのプラットフォームに合わせる
+    platform: linux/x86_64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,11 +40,6 @@ services:
       - DOCKER_INFLUXDB_INIT_ORG=satellite-cloud
       - DOCKER_INFLUXDB_INIT_BUCKET=simulation
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=admin-token
-    # 起動前にデータを全部削除してから influxd を立ち上げ
-    command: >
-      sh -c "rm -rf /var/lib/influxdb2/* && influxd"
-    volumes:
-      - log-db/influxdb_data:/var/lib/influxdb2
 
   simulator:
     container_name: simulator

--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -56,14 +56,15 @@ RUN npm install .
 # CMD npm run devtools:sils
 
 # Runner
-WORKDIR /root/
-COPY /requirements.txt .
 
 RUN python3 -m venv /opt/venv && \
     . /opt/venv/bin/activate && \
-    pip install --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --upgrade pip
 ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /root/
+COPY /requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY /runner_api.py .
 

--- a/simulator/requirements.txt
+++ b/simulator/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.12
 uvicorn==0.34.1
 python-multipart==0.0.20
+influxdb-client[async]==1.48.0

--- a/simulator/runner_api.py
+++ b/simulator/runner_api.py
@@ -8,6 +8,9 @@ import uuid
 import json
 from fastapi import FastAPI, File, Form, UploadFile, HTTPException
 from fastapi.responses import StreamingResponse
+from influxdb_client import Point, WritePrecision
+from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
+from datetime import datetime
 
 app = FastAPI()
 
@@ -18,6 +21,11 @@ UPLOAD_DIR.mkdir(exist_ok=True)
 
 S2E_WORKING_DIR = Path('./aobc-sils/s2e/')
 S2E_EXEC_FILE = Path('./build/S2E_AOBC')
+S2E_LOG_DIR = Path('./aobc-sils/s2e/logs/')
+
+LOGDB_URL = 'http://log-db:8086/'
+LOGDB_ORG = 'satellite-cloud'
+LOGDB_TOKEN = 'admin-token'
 
 class Simulation:
     id_counter = 0
@@ -40,6 +48,7 @@ class Simulation:
 
         self.queue = asyncio.Queue()
 
+        asyncio.create_task(self.read_and_insert_log())
         asyncio.create_task(self.run_and_stream())
 
     def stop(self):
@@ -48,6 +57,76 @@ class Simulation:
         if self.app_process and self.app_process.returncode is None:
             self.app_process.terminate()
         self.status = self.Status.STOPPED
+
+    async def read_and_insert_log(self):
+        # Find the newest log file created after the current time
+        current_time = datetime.now().timestamp()
+        newest_log_file = None
+        while self.status == self.Status.RUNNING:
+            log_files = list(S2E_LOG_DIR.glob("logs_*/*_default.csv"))
+            if not log_files:
+                await asyncio.sleep(0.1)
+                continue
+
+            newest_log_file = max(log_files, key=lambda f: f.stat().st_mtime)
+            if newest_log_file.stat().st_mtime > current_time:
+                break
+            await asyncio.sleep(0.1)
+
+        if not newest_log_file:
+            raise ValueError("No log file found.")
+
+        async with InfluxDBClientAsync(url=LOGDB_URL, token=LOGDB_TOKEN, org=LOGDB_ORG) as client:
+            write_api = client.write_api()
+
+            # Open the newest log file and stream its content
+            with newest_log_file.open("r") as log_file:
+                chunk_size = 1024
+                sleep_sec = 1
+                buffer = ''
+
+                header = []
+
+                while self.status == self.Status.RUNNING:
+                    chunk = log_file.read(chunk_size)
+                    if not chunk:
+                        await asyncio.sleep(sleep_sec)
+                        continue
+                    buffer += chunk
+
+                    points = []
+
+                    while "\n" in buffer:
+                        line, buffer = buffer.split("\n", 1)
+
+                        if header == []:
+                            header = line.split(',')
+                            continue
+
+                        values = line.split(',')
+                        try:
+                            time = datetime.strptime(values[1], '%Y/%m/%d %H:%M:%S.%f')
+                        except ValueError:
+                            print(f"Invalid time format: {values[1]}")
+                            continue
+
+                        point = Point(self.id).time(time, WritePrecision.MS)
+
+                        for i, name in enumerate(header):
+                            if not name: continue
+                            if i == 1:
+                                pass
+                            else:
+                                point.field(name, float(values[i]))
+                        points.append(point)
+
+                    success = await write_api.write(bucket='simulation', record=points)
+                    if not success:
+                        raise ValueError(f'Failed to write points to InfluxDB, {success}')
+
+
+
+        
 
     async def run_and_stream(self):
         print('running app')
@@ -120,6 +199,7 @@ async def run_simulation(
         return sim.to_dict()
     
     except Exception as e:
+        raise e
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/simulator/runner_api.py
+++ b/simulator/runner_api.py
@@ -11,6 +11,7 @@ from fastapi.responses import StreamingResponse
 from influxdb_client import Point, WritePrecision
 from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
 from datetime import datetime
+import uuid
 
 app = FastAPI()
 
@@ -28,7 +29,6 @@ LOGDB_ORG = 'satellite-cloud'
 LOGDB_TOKEN = 'admin-token'
 
 class Simulation:
-    id_counter = 0
 
     class Status(StrEnum):
         RUNNING   = 'running'
@@ -37,8 +37,7 @@ class Simulation:
         FAILED    = 'failed'
 
     def __init__(self, condition: Dict, app_path: Path):
-        self.id = str(self.id_counter)
-        Simulation.id_counter += 1
+        self.id = str(uuid.uuid4())
 
         self.status = self.Status.RUNNING
         self.app_path = app_path

--- a/simulator/runner_api.py
+++ b/simulator/runner_api.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, File, Form, UploadFile, HTTPException
 from fastapi.responses import StreamingResponse
 from influxdb_client import Point, WritePrecision
 from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
-from datetime import datetime
+from datetime import datetime, timedelta
 import uuid
 
 app = FastAPI()
@@ -41,6 +41,9 @@ class Simulation:
 
         self.status = self.Status.RUNNING
         self.app_path = app_path
+
+        self.start_datetime = datetime(2023, 2, 10)
+        self.end_datetime = datetime(2023, 2, 10) + timedelta(seconds=5000)
 
     def run(self):
         self.s2e_process = subprocess.Popen(str(S2E_EXEC_FILE), cwd=str(S2E_WORKING_DIR))
@@ -124,9 +127,6 @@ class Simulation:
                         raise ValueError(f'Failed to write points to InfluxDB, {success}')
 
 
-
-        
-
     async def run_and_stream(self):
         print('running app')
         self.app_process = await asyncio.create_subprocess_exec(
@@ -157,7 +157,9 @@ class Simulation:
     def to_dict(self):
         return {
             'id': self.id,
-            'status': self.status
+            'status': self.status,
+            'start_date_time': self.start_datetime.isoformat(),
+            'end_date_time': self.end_datetime.isoformat(),
         }
     
 @app.get('/')


### PR DESCRIPTION

#4 

- influxDBを log-db という名前のコンテナで動かす
- S2Eのログをinflux DBに挿入する（ほぼリアルタイム）
  -  measurement は simulation id (uuid）
  -  time はシミュレーション内絶対時刻(UTC)
  - その他fieldは，S2Eログのヘッダそのまま．値はfloat
- シミュレーション情報のエンドポイントで，開始・終了時刻も返すようにした