### PR TITLE
Feature/grafana configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pyenv
 Vagrantfile
 
 log-db/influxdb_data
+.vscode/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,13 +31,19 @@ services:
       - "3000:3000"
     volumes:
       - grafana-storage:/var/lib/grafana
+      - ./grafana/datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
+      - ./grafana/dashboard-settings.yaml:/etc/grafana/provisioning/dashboards/dashboard-settings.yaml
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
     environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=adminadmin
       - GF_FEATURE_TOGGLES_ENABLE=publicDashboards
       - GF_SECURITY_ALLOW_EMBEDDING=true
       - GF_SECURITY_COOKIE_SAMESITE=none
       - GF_SECURITY_COOKIE_SECURE=true
-    #depends_on:
-    #- influxdb logdbが出来次第追記
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+    depends_on:
+      - log-db
 
   log-db:
     image: influxdb:2.7.11
@@ -70,7 +76,7 @@ services:
     volumes:
       - ./simulator/tmtc-c2a:/root/tmtc-c2a
       - cargo-target:/root/tmtc-c2a/target
-    
+
 volumes:
   grafana-storage:
   cargo-target:

--- a/grafana/dashboard-settings.yaml
+++ b/grafana/dashboard-settings.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: dashboards
+    type: file
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/dashboards/dashboard.json
+++ b/grafana/dashboards/dashboard.json
@@ -1,0 +1,955 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "P951FEA4DE68E13C5"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "degree"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_latitude[rad]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Latitude"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_longitude[rad]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Longuitude"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_latitude[rad]\")\r\n  |> map(fn: (r) => ({r with _value: r._value * 180.0 / math.pi}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_longitude[rad]\")\r\n  |> map(fn: (r) => ({r with _value: r._value * 180.0 / math.pi}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "B"
+        }
+      ],
+      "title": "Position",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "P951FEA4DE68E13C5"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "degree"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_latitude[rad]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Latitude"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_longitude[rad]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Longuitude"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_altitude[m]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Altitude"
+              },
+              {
+                "id": "unit",
+                "value": "lengthkm"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_altitude[m]\")\r\n  |> map(fn: (r) => ({r with _value: r._value / 1000.0}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "C"
+        }
+      ],
+      "title": "Altitude",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "P951FEA4DE68E13C5"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "velocityms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_velocity_i_x[m/s]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "X Velocity"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_velocity_i_y[m/s]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Y Velocity"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_velocity_i_z[m/s]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Z Velocity"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_velocity_i_x[m/s]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_velocity_i_y[m/s]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_velocity_i_z[m/s]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "C"
+        }
+      ],
+      "title": "Velocity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "P951FEA4DE68E13C5"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "accMS2"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_acceleration_i_x[m/s2]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "X Acceleration"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_acceleration_i_y[m/s2]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Y Acceleration"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_acceleration_i_z[m/s2]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Z Acceleration"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_acceleration_i_x[m/s2]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_acceleration_i_y[m/s2]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_acceleration_i_z[m/s2]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "C"
+        }
+      ],
+      "title": "Acceleration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "P951FEA4DE68E13C5"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "degree"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_latitude[rad]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Latitude"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_longitude[rad]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Longuitude"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_altitude[m]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Altitude"
+              },
+              {
+                "id": "unit",
+                "value": "lengthkm"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_latitude[rad]\")\r\n  |> map(fn: (r) => ({r with _value: r._value * 180.0 / math.pi}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_longitude[rad]\")\r\n  |> map(fn: (r) => ({r with _value: r._value * 180.0 / math.pi}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_altitude[m]\")\r\n  |> map(fn: (r) => ({r with _value: r._value / 1000.0}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "C"
+        }
+      ],
+      "title": "Position",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "P951FEA4DE68E13C5"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "velocityms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_velocity_i_x[m/s]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "X Velocity"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_velocity_i_y[m/s]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Y Velocity"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_velocity_i_z[m/s]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Z Velocity"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_velocity_i_x[m/s]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_velocity_i_y[m/s]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_velocity_i_z[m/s]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "C"
+        }
+      ],
+      "title": "Velocity",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "P951FEA4DE68E13C5"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "accMS2"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_acceleration_i_x[m/s2]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "X Acceleration"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_acceleration_i_y[m/s2]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Y Acceleration"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "spacecraft_acceleration_i_z[m/s2]"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Z Acceleration"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_acceleration_i_x[m/s2]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_acceleration_i_y[m/s2]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "P951FEA4DE68E13C5"
+          },
+          "hide": false,
+          "query": "import \"math\"\r\n\r\nfrom(bucket: \"simulation\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"${id}\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"spacecraft_acceleration_i_z[m/s2]\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\r\n  |> yield(name: \"mean\")\r\n",
+          "refId": "C"
+        }
+      ],
+      "title": "Acceleration",
+      "type": "stat"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "00a5fdff-99ea-4dfa-bab0-4333e18e2f3c",
+          "value": "00a5fdff-99ea-4dfa-bab0-4333e18e2f3c"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "P951FEA4DE68E13C5"
+        },
+        "definition": "import \"influxdata/influxdb/schema\"\r\n\r\nschema.measurements(bucket: \"simulation\")",
+        "label": "Simulation ID",
+        "name": "id",
+        "options": [],
+        "query": {
+          "query": "import \"influxdata/influxdb/schema\"\r\n\r\nschema.measurements(bucket: \"simulation\")"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "2023-02-09T15:00:00.000Z",
+    "to": "2023-02-10T14:59:59.000Z"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "New dashboard",
+  "uid": "aek4rk7eb8um8d",
+  "version": 19
+}

--- a/grafana/datasource.yaml
+++ b/grafana/datasource.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+prune: true
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://log-db:8086
+    basicAuth: false
+    jsonData:
+      version: Flux
+      defaultBucket: simulation
+      organization: satellite-cloud
+      tlsSkipVerify: true
+    secureJsonData:
+      token: admin-token

--- a/web-console/src/components/Grafana.tsx
+++ b/web-console/src/components/Grafana.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Box, Tab, Tabs } from "@mui/material";
 import ImagesBoard from "./DashboardPanel/ImagesBoard";
-import { handleGetImages } from "../utils/data";
 import { useLoaderData } from "react-router";
 
 interface TabPanelProps {
@@ -12,6 +11,21 @@ interface TabPanelProps {
 
 export default function Grafana() {
   const [value, setValue] = React.useState(0);
+  const { simulation, simulationResult } = useLoaderData();
+  const simulationId = simulation ? simulation.id : "";
+
+  const startTime =
+    simulationResult && simulationResult.length > 0
+      ? simulationResult[0]._time
+      : null;
+  const endTime =
+    simulationResult && simulationResult.length > 0
+      ? simulationResult[simulationResult.length - 1]._time
+      : null;
+
+  const getGrafanaTime = (isoString: string) => {
+    return new Date(isoString).getTime();
+  };
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
@@ -56,15 +70,14 @@ export default function Grafana() {
 
       {value === 0 && (
         <iframe
-          src="http://localhost:3000/public-dashboards/6fefc76edf5c450ba3a4e2d27508ed0f"
-          style={{
-            width: "100%",
-            height: "100%",
-            border: "none",
-            overflow: "hidden",
-            backgroundColor: "black",
-          }}
-        />
+          src={`http://localhost:3000/d/aek4rk7eb8um8d/new-dashboard?orgId=1&from=${
+            startTime ? getGrafanaTime(startTime) : "now-6h"
+          }&to=${
+            endTime ? getGrafanaTime(endTime) : "now"
+          }&timezone=browser&var-id=${simulationId}&kiosk`}
+          width="100%"
+          height="100%"
+        ></iframe>
       )}
       {value === 1 && <ImagesBoard width={"100%"} height={"100%"} />}
     </div>

--- a/web-console/src/components/SimulationPanel/SchedulerScreen/SchedulerScreen.tsx
+++ b/web-console/src/components/SimulationPanel/SchedulerScreen/SchedulerScreen.tsx
@@ -14,7 +14,6 @@ export default function SchedulerScreen() {
     useLoaderData();
 
   const scheduler = useAtomValue(schedulerAtom);
-  console.log("Scheduler:", scheduler);
 
   const fetcher = useFetcher();
   return (

--- a/web-console/src/components/SimulationPanel/SchedulerScreen/SchedulerScreen.tsx
+++ b/web-console/src/components/SimulationPanel/SchedulerScreen/SchedulerScreen.tsx
@@ -19,8 +19,8 @@ export default function SchedulerScreen() {
   return (
     <div
       style={{
-        position: "relative",
-        flex: 1,
+        width: "100%",
+        height: "100%",
       }}
     >
       {/* <ButtonGroup sx={{ position: "absolute", top: 10, left: 10, zIndex: 1 }}>

--- a/web-console/src/components/SimulationPanel/SimulationPanel.tsx
+++ b/web-console/src/components/SimulationPanel/SimulationPanel.tsx
@@ -19,9 +19,6 @@ export default function SimulationPanel() {
     <div
       style={{
         position: "relative",
-        display: "flex",
-        flexDirection: "column",
-
         width: "100%",
         height: "100%",
       }}

--- a/web-console/src/components/SimulationPanel/SimulationScreen/SimulationRenderer.tsx
+++ b/web-console/src/components/SimulationPanel/SimulationScreen/SimulationRenderer.tsx
@@ -6,7 +6,6 @@ import Earth from "../../Three/Earth";
 import Satellite from "../../Three/Satellite";
 
 export default function SimulationRenderer({ simulationResult }) {
-  console.log("Simulation List:", simulationResult);
   return (
     <Canvas
       gl={{

--- a/web-console/src/components/SimulationPanel/SimulationScreen/SimulationScreen.tsx
+++ b/web-console/src/components/SimulationPanel/SimulationScreen/SimulationScreen.tsx
@@ -1,23 +1,108 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useLoaderData } from "react-router";
 import SimulationRenderer from "./SimulationRenderer";
 import { useAtomValue } from "jotai";
-import { getCurrentSimulationTimeAtom } from "../../../utils/atoms";
+import {
+  currentSimulationAtom,
+  getCurrentSimulationTimeAtom,
+} from "../../../utils/atoms";
+
+const styles = {
+  dataContainer: {
+    // position: "absolute",
+    color: "white",
+    position: "absolute" as const,
+    zIndex: 1,
+    display: "grid",
+    gridTemplateColumns: "160px 100px",
+    gap: "4px",
+    padding: "12px",
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    borderRadius: "4px",
+    fontFamily: "monospace",
+  },
+  label: {
+    textAlign: "left" as const,
+    paddingRight: "8px",
+  },
+  value: {
+    textAlign: "left" as const,
+  },
+};
 
 export default function SimulationScreen() {
   const { simulationResult } = useLoaderData();
 
   const currentSimulationTime = useAtomValue(getCurrentSimulationTimeAtom);
+  const currentSimulation = useAtomValue(currentSimulationAtom);
+
+  const formatValue = (value: number) => value?.toFixed(8) ?? "N/A";
+
   return (
-    <div
-      style={{
-        position: "relative",
-        flex: 1,
-      }}
-    >
-      <div style={{ position: "absolute", color: "white", zIndex: 1 }}>
-        {currentSimulationTime}
-      </div>
+    <div style={{ width: "100%", height: "100%" }}>
+      {currentSimulation !== null ? (
+        <div style={styles.dataContainer}>
+          <div style={styles.label}>Time:</div>
+          <div style={styles.value}>{currentSimulationTime}</div>
+
+          <div style={styles.label}>Latitude:</div>
+          <div style={styles.value}>
+            {formatValue(
+              (currentSimulation["spacecraft_latitude[rad]"] * 180) / Math.PI
+            )}
+          </div>
+
+          <div style={styles.label}>Longitude:</div>
+          <div style={styles.value}>
+            {formatValue(
+              (currentSimulation["spacecraft_longitude[rad]"] * 180) / Math.PI
+            )}
+          </div>
+
+          <div style={styles.label}>Altitude[m]:</div>
+          <div style={styles.value}>
+            {formatValue(currentSimulation["spacecraft_altitude[m]"])}
+          </div>
+
+          <div style={styles.label}>X Velocity[m/s]:</div>
+          <div style={styles.value}>
+            {formatValue(currentSimulation["spacecraft_velocity_i_x[m/s]"])}
+          </div>
+
+          <div style={styles.label}>Y Velocity[m/s]:</div>
+          <div style={styles.value}>
+            {formatValue(currentSimulation["spacecraft_velocity_i_y[m/s]"])}
+          </div>
+
+          <div style={styles.label}>Z Velocity[m/s]:</div>
+          <div style={styles.value}>
+            {formatValue(currentSimulation["spacecraft_velocity_i_z[m/s]"])}
+          </div>
+
+          <div style={styles.label}>X Acceleration[m/s2]:</div>
+          <div style={styles.value}>
+            {formatValue(
+              currentSimulation["spacecraft_acceleration_i_x[m/s2]"]
+            )}
+          </div>
+
+          <div style={styles.label}>Y Acceleration[m/s2]:</div>
+          <div style={styles.value}>
+            {formatValue(
+              currentSimulation["spacecraft_acceleration_i_y[m/s2]"]
+            )}
+          </div>
+
+          <div style={styles.label}>Z Acceleration[m/s2]:</div>
+          <div style={styles.value}>
+            {formatValue(
+              currentSimulation["spacecraft_acceleration_i_z[m/s2]"]
+            )}
+          </div>
+        </div>
+      ) : (
+        <div style={styles.dataContainer}>No Simulation</div>
+      )}
       <SimulationRenderer simulationResult={simulationResult} />
     </div>
   );

--- a/web-console/src/components/SimulationPanel/SimulationScreen/SimulationScreen.tsx
+++ b/web-console/src/components/SimulationPanel/SimulationScreen/SimulationScreen.tsx
@@ -6,29 +6,7 @@ import {
   currentSimulationAtom,
   getCurrentSimulationTimeAtom,
 } from "../../../utils/atoms";
-
-const styles = {
-  dataContainer: {
-    // position: "absolute",
-    color: "white",
-    position: "absolute" as const,
-    zIndex: 1,
-    display: "grid",
-    gridTemplateColumns: "160px 100px",
-    gap: "4px",
-    padding: "12px",
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
-    borderRadius: "4px",
-    fontFamily: "monospace",
-  },
-  label: {
-    textAlign: "left" as const,
-    paddingRight: "8px",
-  },
-  value: {
-    textAlign: "left" as const,
-  },
-};
+import SimulationStats from "./SimulationStats";
 
 export default function SimulationScreen() {
   const { simulationResult } = useLoaderData();
@@ -41,67 +19,19 @@ export default function SimulationScreen() {
   return (
     <div style={{ width: "100%", height: "100%" }}>
       {currentSimulation !== null ? (
-        <div style={styles.dataContainer}>
-          <div style={styles.label}>Time:</div>
-          <div style={styles.value}>{currentSimulationTime}</div>
-
-          <div style={styles.label}>Latitude:</div>
-          <div style={styles.value}>
-            {formatValue(
-              (currentSimulation["spacecraft_latitude[rad]"] * 180) / Math.PI
-            )}
-          </div>
-
-          <div style={styles.label}>Longitude:</div>
-          <div style={styles.value}>
-            {formatValue(
-              (currentSimulation["spacecraft_longitude[rad]"] * 180) / Math.PI
-            )}
-          </div>
-
-          <div style={styles.label}>Altitude[m]:</div>
-          <div style={styles.value}>
-            {formatValue(currentSimulation["spacecraft_altitude[m]"])}
-          </div>
-
-          <div style={styles.label}>X Velocity[m/s]:</div>
-          <div style={styles.value}>
-            {formatValue(currentSimulation["spacecraft_velocity_i_x[m/s]"])}
-          </div>
-
-          <div style={styles.label}>Y Velocity[m/s]:</div>
-          <div style={styles.value}>
-            {formatValue(currentSimulation["spacecraft_velocity_i_y[m/s]"])}
-          </div>
-
-          <div style={styles.label}>Z Velocity[m/s]:</div>
-          <div style={styles.value}>
-            {formatValue(currentSimulation["spacecraft_velocity_i_z[m/s]"])}
-          </div>
-
-          <div style={styles.label}>X Acceleration[m/s2]:</div>
-          <div style={styles.value}>
-            {formatValue(
-              currentSimulation["spacecraft_acceleration_i_x[m/s2]"]
-            )}
-          </div>
-
-          <div style={styles.label}>Y Acceleration[m/s2]:</div>
-          <div style={styles.value}>
-            {formatValue(
-              currentSimulation["spacecraft_acceleration_i_y[m/s2]"]
-            )}
-          </div>
-
-          <div style={styles.label}>Z Acceleration[m/s2]:</div>
-          <div style={styles.value}>
-            {formatValue(
-              currentSimulation["spacecraft_acceleration_i_z[m/s2]"]
-            )}
-          </div>
-        </div>
+        <SimulationStats />
       ) : (
-        <div style={styles.dataContainer}>No Simulation</div>
+        <div
+          style={{
+            position: "absolute",
+            zIndex: 1,
+            color: "white",
+            margin: "12px",
+            fontFamily: "monospace",
+          }}
+        >
+          No Simulation
+        </div>
       )}
       <SimulationRenderer simulationResult={simulationResult} />
     </div>

--- a/web-console/src/components/SimulationPanel/SimulationScreen/SimulationScreen.tsx
+++ b/web-console/src/components/SimulationPanel/SimulationScreen/SimulationScreen.tsx
@@ -8,7 +8,6 @@ export default function SimulationScreen() {
   const { simulationResult } = useLoaderData();
 
   const currentSimulationTime = useAtomValue(getCurrentSimulationTimeAtom);
-  console.log("Simulation List:", simulationResult);
   return (
     <div
       style={{

--- a/web-console/src/components/SimulationPanel/SimulationScreen/SimulationStats.tsx
+++ b/web-console/src/components/SimulationPanel/SimulationScreen/SimulationStats.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from "react";
+import { useAtomValue } from "jotai";
+import {
+  currentSimulationAtom,
+  getCurrentSimulationTimeAtom,
+} from "../../../utils/atoms";
+
+const styles = {
+  dataContainer: {
+    color: "white",
+    position: "absolute" as const,
+    zIndex: 1,
+    // display: "grid",
+    // gridTemplateColumns: "160px 100px",
+    // gap: "4px",
+    padding: "12px",
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    borderRadius: "4px",
+    fontFamily: "monospace",
+  },
+  label: {
+    textAlign: "left" as const,
+    paddingRight: "8px",
+  },
+  value: {
+    textAlign: "left" as const,
+  },
+};
+
+export default function SimulationStats() {
+  const currentSimulationTime = useAtomValue(getCurrentSimulationTimeAtom);
+  const currentSimulation = useAtomValue(currentSimulationAtom);
+  const [isOpen, setIsOpen] = useState(true);
+
+  const formatValue = (value: number) => value?.toFixed(8) ?? "N/A";
+  return (
+    <div style={styles.dataContainer}>
+      <button
+        style={{
+          marginBottom: "4px",
+          padding: "4px",
+          backgroundColor: "rgba(30, 30, 30, 0.9)",
+          border: "none",
+          color: "white",
+          borderRadius: "4px",
+        }}
+        onClick={() => {
+          setIsOpen((prev) => !prev);
+        }}
+      >
+        {isOpen ? "Hide Data" : "Show Data"}
+      </button>
+      {isOpen && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "160px 100px",
+            gap: "4px",
+          }}
+        >
+          <div style={styles.label}>Time:</div>
+          <div style={styles.value}>{currentSimulationTime}</div>
+
+          <div style={styles.label}>Latitude:</div>
+          <div style={styles.value}>
+            {formatValue(
+              (currentSimulation["spacecraft_latitude[rad]"] * 180) / Math.PI
+            )}
+          </div>
+
+          <div style={styles.label}>Longitude:</div>
+          <div style={styles.value}>
+            {formatValue(
+              (currentSimulation["spacecraft_longitude[rad]"] * 180) / Math.PI
+            )}
+          </div>
+
+          <div style={styles.label}>Altitude[m]:</div>
+          <div style={styles.value}>
+            {formatValue(currentSimulation["spacecraft_altitude[m]"])}
+          </div>
+
+          <div style={styles.label}>X Velocity[m/s]:</div>
+          <div style={styles.value}>
+            {formatValue(currentSimulation["spacecraft_velocity_i_x[m/s]"])}
+          </div>
+
+          <div style={styles.label}>Y Velocity[m/s]:</div>
+          <div style={styles.value}>
+            {formatValue(currentSimulation["spacecraft_velocity_i_y[m/s]"])}
+          </div>
+
+          <div style={styles.label}>Z Velocity[m/s]:</div>
+          <div style={styles.value}>
+            {formatValue(currentSimulation["spacecraft_velocity_i_z[m/s]"])}
+          </div>
+
+          <div style={styles.label}>X Acceleration[m/s2]:</div>
+          <div style={styles.value}>
+            {formatValue(
+              currentSimulation["spacecraft_acceleration_i_x[m/s2]"]
+            )}
+          </div>
+
+          <div style={styles.label}>Y Acceleration[m/s2]:</div>
+          <div style={styles.value}>
+            {formatValue(
+              currentSimulation["spacecraft_acceleration_i_y[m/s2]"]
+            )}
+          </div>
+
+          <div style={styles.label}>Z Acceleration[m/s2]:</div>
+          <div style={styles.value}>
+            {formatValue(
+              currentSimulation["spacecraft_acceleration_i_z[m/s2]"]
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-console/src/components/Three/Satellite.tsx
+++ b/web-console/src/components/Three/Satellite.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from "react";
 import * as THREE from "three";
 import { useFrame } from "@react-three/fiber";
 import {
+  currentSimulationAtom,
   currentSimulationTimeAlphaAtom,
   currentSimulationTimeAtom,
   getCurrentSimulationTimeAtom,
@@ -26,6 +27,9 @@ export default function Satellite({ simulationResult }) {
 
   const [currentTime, setCurrentTime] = useAtom(currentSimulationTimeAtom);
   const [nextTime, setNextTime] = useAtom(nextSimulationTimeAtom);
+  const [currentSimulation, setCurrentSimulation] = useAtom(
+    currentSimulationAtom
+  );
   const [alpha, setAlpha] = useAtom(currentSimulationTimeAlphaAtom);
 
   const satelliteModel = useLoader(GLTFLoader, "/models/satellite.glb");
@@ -42,6 +46,7 @@ export default function Satellite({ simulationResult }) {
 
     // Get quaternion values
     const current = simulationResult[currentIndex];
+    setCurrentSimulation(current);
     setCurrentTime(current._time);
     const next = simulationResult[nextIndex];
     setNextTime(next._time);

--- a/web-console/src/route.ts
+++ b/web-console/src/route.ts
@@ -75,7 +75,16 @@ async function loader({ params }: LoaderFunctionArgs) {
     r["_field"] =~ /^spacecraft_quaternion_i2b_[wxyz]$/ or 
     r["_field"] == "spacecraft_position_i_x[m]" or 
     r["_field"] == "spacecraft_position_i_y[m]" or 
-    r["_field"] == "spacecraft_position_i_z[m]"  
+    r["_field"] == "spacecraft_position_i_z[m]" or 
+    r["_field"] == "spacecraft_latitude[rad]" or
+    r["_field"] == "spacecraft_longitude[rad]" or
+    r["_field"] == "spacecraft_altitude[m]" or
+    r["_field"] == "spacecraft_velocity_i_x[m/s]" or
+    r["_field"] == "spacecraft_velocity_i_y[m/s]" or
+    r["_field"] == "spacecraft_velocity_i_z[m/s]" or
+    r["_field"] == "spacecraft_acceleration_i_x[m/s2]" or
+    r["_field"] == "spacecraft_acceleration_i_y[m/s2]" or
+    r["_field"] == "spacecraft_acceleration_i_z[m/s2]" 
   )
   |> group(columns: ["_measurement", "_field"]) // Group by measurement and field
   |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)

--- a/web-console/src/utils/atoms.ts
+++ b/web-console/src/utils/atoms.ts
@@ -54,6 +54,8 @@ const getCurrentSimulationTimeAtom = atom((get) => {
   return null;
 });
 
+const currentSimulationAtom = atom<any>(null);
+
 export {
   schedulerAtom,
   getCurrentSimulationTimeAtom,
@@ -64,6 +66,7 @@ export {
   outputtLogAtom,
   appendOutputLogAtom,
   clearOutputLogAtom,
+  currentSimulationAtom,
 };
 
 // export {


### PR DESCRIPTION
* Grafanaを設定しました。ログインなしでデータの閲覧のみは可能な設定にすることで、Public DashBoardに設定しなくともウェブコンソールに埋め込むことができました。
* urlでシミュレーションIDと開始時刻・終了時刻を指定しているため新しいシミュレーションを走らせたり、シミュレーションを切り替えることで表示されるデータが更新されます。
* シミュレーション画面にもテレメトリを表示しました。
![image](https://github.com/user-attachments/assets/f6e8c0e1-c139-4258-b813-d8d8c9a0b2f9)
